### PR TITLE
Fix installation when Pillow is not installed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
-install: "pip install Pillow"
+install: "pip install ."
 script: "py.test ."

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ from setuptools import setup, find_packages
 def get_version(relpath):
   """Read version info from a file without importing it"""
   from os.path import dirname, join
+  root = dirname(__file__)
   for line in open(join(root, relpath), "rb"):
     # encoding is not passed to open() parameter, because
     # it is incompatible with Python 2

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,16 @@
 
 from setuptools import setup, find_packages
 
-from almonds import __version__
+def get_version(relpath):
+  """Read version info from a file without importing it"""
+  from os.path import dirname, join
+  for line in open(join(root, relpath), "rb"):
+    # encoding is not passed to open() parameter, because
+    # it is incompatible with Python 2
+    line = line.decode("utf-8")
+    if "__version__" in line:
+      if '"' in line:
+        return line.split('"')[1]
 
 readme_file = open("readme_pypi.rst", "r")
 README = readme_file.read()
@@ -11,7 +20,7 @@ readme_file.close()
 setup(
     name="almonds",
     packages=find_packages(),
-    version=__version__,
+    version=get_version("almonds/almonds.py"),
     description="Terminal fractal viewer",
     long_description=README,
     author="Tenchi",

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ def get_version(relpath):
     if "__version__" in line:
       if '"' in line:
         return line.split('"')[1]
+VERSION = get_version("almonds/almonds.py")
 
 readme_file = open("readme_pypi.rst", "r")
 README = readme_file.read()
@@ -21,13 +22,13 @@ readme_file.close()
 setup(
     name="almonds",
     packages=find_packages(),
-    version=get_version("almonds/almonds.py"),
+    version=VERSION,
     description="Terminal fractal viewer",
     long_description=README,
     author="Tenchi",
     author_email="tenkage@gmail.com",
     url="https://github.com/Tenchi2xh/Almonds",
-    download_url="https://github.com/Tenchi2xh/Almonds/tarball/" + __version__,
+    download_url="https://github.com/Tenchi2xh/Almonds/tarball/" + VERSION,
     keywords=["fractal", "mandelbrot", "terminal", "termbox", "curses"],
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
Right now `pip` fails while scanning for dependencies. setup.py should
not import package that is not yet installed.

```
>pip install almonds
Collecting almonds
  Downloading almonds-1.25b.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "c:\users\user\appdata\local\temp2\pip-build-amxwdz\almonds\setup.py", line 5, in <module>
        from almonds import __version__
     File "almonds\__init__.py", line 1, in <module>
        from .almonds import __version__
      File "almonds\almonds.py", line 13, in <module>
        from PIL import Image
    ImportError: No module named PIL
```
